### PR TITLE
Enhance timezones support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gem "pry"
 gem "rake"
 gem "sequel"
 gem "pg"
+
+gem "tzinfo", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,8 @@ GEM
       inflecto
       virtus
     thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -43,6 +45,7 @@ DEPENDENCIES
   rake
   sequel
   telegram-bot-ruby
+  tzinfo (~> 1.2)
 
 BUNDLED WITH
-   1.14.6
+   1.16.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require 'tzinfo'
 require_relative './telegram_handler'
 require_relative './weather'
 
@@ -13,8 +14,13 @@ task :hourly do
         end
         next
       end
+      if (!!current_user[:timezone])
+        reference_time = TZInfo::Timezone.get(current_user[:timezone]).now
+      else
+        reference_time = Time.now
+      end
 
-      next if current_user[:hour_to_send].to_i != Time.now.hour.to_i
+      next if current_user[:hour_to_send].to_i != reference_time.hour.to_i
 
       # Get the weather here
       rain = Weather.will_it_rain?(lat: current_user[:lat], lng: current_user[:lng])

--- a/database.rb
+++ b/database.rb
@@ -11,6 +11,7 @@ class Database
         Float :lat
         Float :lng
         String :hour_to_send
+        String :timezone
       end
     end
 

--- a/telegram_handler.rb
+++ b/telegram_handler.rb
@@ -101,12 +101,11 @@ class TelegramHandler
     u = current_user(chat_id: message.chat.id).first
     result = Weather.fetch_weather(location: "#{u[:lat]},#{u[:lng]}")
     location = (result || {})["location"]
-    time_diff = ((Time.parse(location["localtime"]) - Time.now) / 60.0 / 60.0).round
-    resulting_number = hour_to_send - time_diff - 1 # we want to warn the user **before** they leave the house
-    resulting_number -= 24 if resulting_number >= 24
+    timezone = (location || {})["tz_id"]
 
     current_user(chat_id: message.chat.id).update(
-      hour_to_send: resulting_number
+      hour_to_send: hour_to_send - 1, # we want to warn the user **before** they leave the house
+      timezone: timezone
     )
     bot.api.send_message(chat_id: message.chat.id, 
         text: "✅ Nice! We'll send you a rain alert right before #{hour_to_send}am if it will rain that day ☔️")


### PR DESCRIPTION
A few months ago, I noticed that the time at which the bot was sending me a reminder was a bit off. A couple of weeks ago, I had that same feeling again - so I gave a second look at the history:

<img width="703" alt="screenshot 2018-11-13 at 11 22 28" src="https://user-images.githubusercontent.com/8390508/48407138-7317f400-e736-11e8-9c8a-f15902dc3c6b.png">

When we went from summertime to wintertime in Europe/Amsterdam, the bot went back one hour. 😅

This PR fixes it by changing the way the hour to send it saved:

+ Currently, the `set_time` determines the time to save in the DB by computing the difference between the current time locally and at the specified location.
+ With this commit, `set_time` saves **both** the time to send, as well as the user's timezone. When the hourly job is triggered, if there's a timezone saved in the DB, it uses it to determine if it's the time to send locally. Otherwise, it uses the machine's local time (to keep compatibility with older saved times).

I'm not too experienced with Ruby, so I'd glad to take any feedback!